### PR TITLE
flip order of weight+bias application in LayerNormANE

### DIFF
--- a/ane_transformers/reference/layer_norm.py
+++ b/ane_transformers/reference/layer_norm.py
@@ -73,7 +73,7 @@ class LayerNormANE(nn.Module):
         out = zero_mean * denom
 
         if self.elementwise_affine:
-            out = (out + self.bias.view(1, self.num_channels, 1, 1)
-                   ) * self.weight.view(1, self.num_channels, 1, 1)
+            out = (out * self.weight.view(1, self.num_channels, 1, 1)
+                   ) + self.bias.view(1, self.num_channels, 1, 1)
 
         return out


### PR DESCRIPTION
Hi, I'm attempting to duplicate the pytorch LayerNorm functionality, and the formula that pytorch uses is clearly `(out * weight) + bias`, which does not match the code in `LayerNormANE`.

So I changed it for my use case, and thought I'd open a PR in case this is in fact a bug.

However.. looking at https://github.com/apple/ml-ane-transformers/commit/4b37184a506364b9c262413ab62610317f2d02c3, it looks like there is some history and/or legacy reasons for the order being this way, so feel free to reject if I'm missing something :)